### PR TITLE
hacky solution to make the chromedriver tests work in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,4 +51,4 @@ before_script:
   - which google-chrome
   - yarn install
 script:
-  - if [[ "$LANGUAGE" == "ruby" ]]; then bundle exec rake; fi
+  - if [[ "$LANGUAGE" == "ruby" ]]; then DRIVER=travis bundle exec rake; fi

--- a/ruby/hyper-spec/lib/hyper-spec.rb
+++ b/ruby/hyper-spec/lib/hyper-spec.rb
@@ -62,6 +62,14 @@ RSpec.configure do |_config|
     Capybara::Selenium::Driver.new(app, browser: :chrome, desired_capabilities: capabilities)
   end
 
+  Capybara.register_driver :chrome_headless_docker_travis do |app|
+    options = ::Selenium::WebDriver::Chrome::Options.new
+    options.add_argument('--headless')
+    options.add_argument('--no-sandbox')
+    options.add_argument('--disable-dev-shm-usage')
+    Capybara::Selenium::Driver.new(app, browser: :chrome, :driver_path => "/usr/lib/chromium-browser/chromedriver", options: options)
+  end
+
   Capybara.register_driver :firefox do |app|
     Capybara::Selenium::Driver.new(app, browser: :firefox)
   end
@@ -92,6 +100,7 @@ RSpec.configure do |_config|
     when 'firefox' then :firefox
     when 'headless' then :selenium_chrome_headless
     when 'safari' then :safari
+    when 'travis' then :chrome_headless_docker_travis
     else :selenium_chrome_headless
     end
 


### PR DESCRIPTION
Getting the chrome based tests to run in travis is a massive pain, as it actually runs in docker.
I had to register a new chrome driver with some extra params to make this work.

you can see my test results here: https://travis-ci.org/mnayob97/hyperstack/builds/430993381

theres probably a cleaner way of doing this....