### PR TITLE
Sort models by id to ensure correct order of children

### DIFF
--- a/ruby/hyper-model/lib/reactive_record/active_record/reactive_record/isomorphic_base.rb
+++ b/ruby/hyper-model/lib/reactive_record/active_record/reactive_record/isomorphic_base.rb
@@ -242,7 +242,7 @@ module ReactiveRecord
           end if record.new? || record.changed? || (record == record_being_saved && force)
           record_index += 1
         end
-        [models, associations, backing_records]
+        [models.sort_by { |model| model[:id] }, associations, backing_records]
       end
 
       def save_or_validate(save, validate, force, &block)

--- a/ruby/hyper-model/spec/spec_helper.rb
+++ b/ruby/hyper-model/spec/spec_helper.rb
@@ -271,13 +271,13 @@ if RUBY_ENGINE != 'opal'
     #   DatabaseCleaner.start
     # end
 
-    config.after(:each) do |example|
-      unless example.exception
-        # Clear session data
-        Capybara.reset_sessions!
-        # Rollback transaction
-        DatabaseCleaner.clean
-      end
+    config.after(:each) do # |example|
+      # unless example.exception
+      # Clear session data
+      Capybara.reset_sessions!
+      # Rollback transaction
+      DatabaseCleaner.clean
+      # end
     end
 
     config.after(:all, :js => true) do


### PR DESCRIPTION
This PR adds a spec and solution to ensure that child models preserve their order based on id.