### PR TITLE
Fixes #215

### DIFF
--- a/ruby/hyper-model/lib/reactive_record/active_record/reactive_record/collection.rb
+++ b/ruby/hyper-model/lib/reactive_record/active_record/reactive_record/collection.rb
@@ -619,12 +619,21 @@ To determine this sync_scopes first asks if the record being changed is in the s
     end
 
     def any?(*args, &block)
-      # If are doing anything other than just checking if there is an object in the collection,
-      # proceed to the normal behavior
-      return super if args&.length&.positive? || block.present?
+      # If there are any args passed in, then the collection is being used in the condition
+      #   and we must load it all into memory.
+      return all.any?(*args, &block) if args&.length&.positive? || block.present?
 
-      # Otherwise just check the count for efficiency
-      count.positive?
+      # Otherwise we can just check the count for efficiency
+      !empty?
+    end
+
+    def none?(*args, &block)
+      # If there are any args passed in, then the collection is being used in the condition
+      #   and we must load it all into memory.
+      return all.none?(*args, &block) if args&.length&.positive? || block.present?
+
+      # Otherwise we can just check the count for efficiency
+      empty?
     end
 
     def method_missing(method, *args, &block)

--- a/ruby/hyper-model/lib/reactive_record/active_record/reactive_record/collection.rb
+++ b/ruby/hyper-model/lib/reactive_record/active_record/reactive_record/collection.rb
@@ -616,8 +616,13 @@ To determine this sync_scopes first asks if the record being changed is in the s
       count.zero?
     end
 
-    def any?
-      !count.zero?
+    def any?(*args, &block)
+      # If are doing anything other than just checking if there is an object in the collection,
+      # proceed to the normal behavior
+      return super if args&.length&.positive? || block.present?
+
+      # Otherwise just check the count for efficiency
+      count.positive?
     end
 
     def method_missing(method, *args, &block)

--- a/ruby/hyper-model/spec/batch2/collection_aggregate_methods_spec.rb
+++ b/ruby/hyper-model/spec/batch2/collection_aggregate_methods_spec.rb
@@ -50,4 +50,40 @@ RSpec::Steps.steps "collection aggregate methods", js: true do
     ).to eq(TestModel.all.send(method))
     end
   end
+
+  it 'will retrieve the entire collection when using any? if an arg is passed in' do
+    FactoryBot.create(:test_model)
+
+    expect_promise(
+      <<~RUBY
+        Hyperstack::Model.load do
+          TestModel.any?(TestModel)
+        end.then do |val|
+          if TestModel.all.instance_variable_get('@collection')
+            'necessary fetch of all'
+          else
+            val
+          end
+        end
+      RUBY
+    ).to eq('necessary fetch of all')
+  end
+
+  it 'will retrieve the entire collection when using any? if a block is passed in' do
+    FactoryBot.create(:test_model)
+
+    expect_promise(
+      <<~RUBY
+        Hyperstack::Model.load do
+          TestModel.any? { |test_model| test_model }
+        end.then do |val|
+          if TestModel.all.instance_variable_get('@collection')
+            'necessary fetch of all'
+          else
+            val
+          end
+        end
+      RUBY
+    ).to eq('necessary fetch of all')
+  end
 end


### PR DESCRIPTION
This fixes the regression from patching `.any?` on a collection to be optimized and not load the entire collection if not needed.

We will now check if an arg or a block is passed in, and if they are continue normal behavior. If not, use the optimized way of just checking the count.