### PR TITLE
Slack links are broken

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ You can be up and running in **less than 5 minutes**. Just follow the simple set
 
 Hyperstack is supported by a friendly, helpful community, both for users, and contributors. We welcome new people, please reach out and say hello.
 
-+ [Join](https://hyperstack.org/slack-invite) our new Slack group
++ [Join](https://hyperstack.org/slack-invite)(needs updating, the link has expired) our new Slack group
 + After you have joined there is a shortcut at https://hyperstack.org/slack
 
 ### StackOverflow Questions


### PR DESCRIPTION
all the slack invitation links have expired, on the hyperstack.org website as  well as in docs.