### PR TITLE
libv8 7.3.492.27.1 and mini_racer 0.2.6

### DIFF
--- a/ruby/hyper-component/hyper-component.gemspec
+++ b/ruby/hyper-component/hyper-component.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'hyper-state', Hyperstack::Component::VERSION
   spec.add_dependency 'hyperstack-config', Hyperstack::Component::VERSION
-  spec.add_dependency 'libv8', '~> 6.7.0'
-  spec.add_dependency 'mini_racer', '~> 0.2.4'
+  spec.add_dependency 'libv8', '~> 7.3.492.27.1'
+  spec.add_dependency 'mini_racer', '~> 0.2.6'
   spec.add_dependency 'opal', '>= 0.11.0', '< 0.12.0'
   spec.add_dependency 'opal-activesupport', '~> 0.3.1'
   spec.add_dependency 'react-rails', '>= 2.4.0', '< 2.5.0'

--- a/ruby/hyper-model/hyper-model.gemspec
+++ b/ruby/hyper-model/hyper-model.gemspec
@@ -32,8 +32,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', ['>= 1.17.3', '< 2.1']
   spec.add_development_dependency 'capybara'
   spec.add_development_dependency 'chromedriver-helper', '1.2.0'
-  spec.add_development_dependency 'libv8'
-  spec.add_development_dependency 'mini_racer', '~> 0.2.4'
+  spec.add_development_dependency 'libv8', '~> 7.3.492.27.1'
+  spec.add_development_dependency 'mini_racer', '~> 0.2.6'
   spec.add_development_dependency 'selenium-webdriver'
   spec.add_development_dependency 'database_cleaner'
   spec.add_development_dependency 'factory_bot_rails'

--- a/ruby/hyper-router/hyper-router.gemspec
+++ b/ruby/hyper-router/hyper-router.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'hyper-spec', HyperRouter::VERSION
   spec.add_development_dependency 'hyper-store', HyperRouter::VERSION
   spec.add_development_dependency 'listen'
-  spec.add_development_dependency 'mini_racer', '~> 0.2.4'
+  spec.add_development_dependency 'mini_racer', '~> 0.2.6'
   spec.add_development_dependency 'opal-rails', '~> 0.9.4'
   spec.add_development_dependency 'parser'
   spec.add_development_dependency 'puma'

--- a/ruby/hyper-spec/hyper-spec.gemspec
+++ b/ruby/hyper-spec/hyper-spec.gemspec
@@ -26,9 +26,9 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
 
   spec.add_dependency 'capybara'
   spec.add_dependency 'chromedriver-helper', '1.2.0'
-  spec.add_dependency 'libv8', '~> 6.7.0'
+  spec.add_dependency 'libv8', '~> 7.3.492.27.1'
   spec.add_dependency 'method_source'
-  spec.add_dependency 'mini_racer', '~> 0.2.4'
+  spec.add_dependency 'mini_racer', '~> 0.2.6'
   spec.add_dependency 'opal', '>= 0.11.0', '< 0.12.0'
   spec.add_dependency 'parser', '>= 2.3.3.1'
   spec.add_dependency 'pry'

--- a/ruby/hyper-store/hyper-store.gemspec
+++ b/ruby/hyper-store/hyper-store.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'hyper-component', Hyperstack::Legacy::Store::VERSION
   spec.add_development_dependency 'hyper-spec', Hyperstack::Legacy::Store::VERSION
   spec.add_development_dependency 'listen'
-  spec.add_development_dependency 'mini_racer', '~> 0.2.4'
+  spec.add_development_dependency 'mini_racer', '~> 0.2.6'
   spec.add_development_dependency 'opal-browser', '~> 0.2.0'
   spec.add_development_dependency 'opal-rails', '~> 0.9.4'
   spec.add_development_dependency 'pry-byebug'

--- a/ruby/hyperstack-config/hyperstack-config.gemspec
+++ b/ruby/hyperstack-config/hyperstack-config.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'listen', '~> 3.0'  # for hot loader
-  spec.add_dependency 'mini_racer', '~> 0.2.4'
+  spec.add_dependency 'mini_racer', '~> 0.2.6'
   spec.add_dependency 'opal', '>= 0.11.0', '< 0.12.0'
   spec.add_dependency 'opal-browser', '~> 0.2.0'
   spec.add_dependency 'uglifier'

--- a/ruby/rails-hyperstack/rails-hyperstack.gemspec
+++ b/ruby/rails-hyperstack/rails-hyperstack.gemspec
@@ -61,8 +61,8 @@ You can control how much of the stack gets installed as well:
 
   spec.add_dependency 'opal-browser', '~> 0.2.0'
   spec.add_dependency 'react-rails', '>= 2.4.0', '< 2.5.0'
-  spec.add_dependency 'mini_racer', '~> 0.2.4'
-  spec.add_dependency 'libv8', '~> 6.7.0'
+  spec.add_dependency 'mini_racer', '~> 0.2.6'
+  spec.add_dependency 'libv8', '~> 7.3.492.27.1'
   spec.add_dependency 'rails', '>= 4.0.0'
 
 


### PR DESCRIPTION
the latest version of libv8 that works on osx 10.15.1 (Catalina)

Tests have NOT been run. 