### PR TITLE
Belongs_to association should not be included automatically into save transactions

### DIFF
--- a/ruby/hyper-model/lib/reactive_record/active_record/instance_methods.rb
+++ b/ruby/hyper-model/lib/reactive_record/active_record/instance_methods.rb
@@ -128,7 +128,8 @@ module ActiveRecord
       return false unless ar_instance.is_a?(ActiveRecord::Base)
       return false if ar_instance.new_record?
       return false unless self.class.base_class == ar_instance.class.base_class
-      id == ar_instance.id
+      return id == ar_instance.id unless id.nil?
+      attributes == ar_instance.attributes
     end
 
     def [](attr)

--- a/ruby/hyper-model/lib/reactive_record/active_record/reactive_record/getters.rb
+++ b/ruby/hyper-model/lib/reactive_record/active_record/reactive_record/getters.rb
@@ -95,7 +95,7 @@ module ReactiveRecord
 
     def getter_common(attribute, reload)
       @virgin = false unless data_loading?
-      return if @destroyed
+      return @attributes[attribute] if @destroyed
       if @attributes.key? attribute
         current_value = @attributes[attribute]
         current_value.notify if current_value.is_a? Base::DummyValue

--- a/ruby/hyper-model/lib/reactive_record/active_record/reactive_record/isomorphic_base.rb
+++ b/ruby/hyper-model/lib/reactive_record/active_record/reactive_record/isomorphic_base.rb
@@ -230,6 +230,7 @@ module ReactiveRecord
           models << {id: record.object_id, model: record.model.model_name.to_s, attributes: output_attributes, vector: vector}
           record.attributes.each do |attribute, value|
             if association = record.model.reflect_on_association(attribute)
+              next if association.macro == :belongs_to
               if association.collection?
                 # following line changed from .all to .collection on 10/28
                 [*value.collection, *value.unsaved_children].each do |assoc|

--- a/ruby/hyper-operation/lib/hyper-operation/exception.rb
+++ b/ruby/hyper-operation/lib/hyper-operation/exception.rb
@@ -1,9 +1,11 @@
 module Mutations
-  class ErrorArray
+  class ErrorHash
     def self.new_from_error_hash(errors)
-      new(errors.collect do |key, values|
-        ErrorAtom.new(key, values[:symbol], values)
-      end)
+			new.tap do |hash|
+				errors.each do |key, values|
+					hash[key] = ErrorAtom.new(key, values[:symbol], values)
+				end
+			end
     end
   end
 end
@@ -30,7 +32,7 @@ module Hyperstack
 
       def initialize(errors)
         unless errors.is_a? Mutations::ErrorHash
-          errors = Mutations::ErrorArray.new_from_error_hash(errors)
+          errors = Mutations::ErrorHash.new_from_error_hash(errors)
         end
         super(errors)
       end

--- a/ruby/hyper-router/lib/hyperstack/internal/router/helpers.rb
+++ b/ruby/hyper-router/lib/hyperstack/internal/router/helpers.rb
@@ -39,6 +39,18 @@ module Hyperstack
           }
         end
 
+        def history
+          Hyperstack::Router::History.new(`#{@__hyperstack_component_native}.props.history`)
+        end
+
+        def location
+          Hyperstack::Router::Location.new(`#{@__hyperstack_component_native}.props.location`)
+        end
+
+        def match
+          Hyperstack::Router::Match.new(`#{@__hyperstack_component_native}.props.match`)
+        end
+
         def Route(to, opts = {}, &block)
           Hyperstack::Internal::State::Mapper.observed! Hyperstack::Router::Location
 


### PR DESCRIPTION
The problem case example:

We have a class Note with `belongs_to: :user`, and User with `has_many: :note`.

A browser app creates some invalid Note object, `note1`, associates it with a user via `note1.user = user`, runs `note1.save` and gets some validation error. Then the app creates another Note object, `note2`, a normal one, associates it with the user via `note2.user = user` and runs `note2.save`. It gets a confusing state: the reactive_record tries to save both `note1` and `note2` in a single transaction, fails with rollback due invalid `note1` and also refuses to save the `note2`.

A similar problem if we create and edit several Note objects associate to a user and save one of them - the backend will save them all.

It's an unexpected behavior, and accroding to https://guides.rubyonrails.org/association_basics.html: "Assigning an object to a belongs_to association does not automatically save the object. It does not save the associated object either."