### PR TITLE
Record comparision fix

### DIFF
--- a/ruby/hyper-model/lib/reactive_record/active_record/instance_methods.rb
+++ b/ruby/hyper-model/lib/reactive_record/active_record/instance_methods.rb
@@ -128,7 +128,8 @@ module ActiveRecord
       return false unless ar_instance.is_a?(ActiveRecord::Base)
       return false if ar_instance.new_record?
       return false unless self.class.base_class == ar_instance.class.base_class
-      id == ar_instance.id
+      return id == ar_instance.id unless id.nil?
+      attributes == ar_instance.attributes
     end
 
     def [](attr)

--- a/ruby/hyper-model/lib/reactive_record/active_record/reactive_record/getters.rb
+++ b/ruby/hyper-model/lib/reactive_record/active_record/reactive_record/getters.rb
@@ -95,7 +95,7 @@ module ReactiveRecord
 
     def getter_common(attribute, reload)
       @virgin = false unless data_loading?
-      return if @destroyed
+      return @attributes[attribute] if @destroyed
       if @attributes.key? attribute
         current_value = @attributes[attribute]
         current_value.notify if current_value.is_a? Base::DummyValue


### PR DESCRIPTION
Destroyed records and invalid records (unsaved) are mistakenly considered equal. Here is a patch to fix the comparison operation as well as to preserve the id of destroyed record (conforming with the Rails behavior)