### PR TITLE
Fixes #226

### DIFF
--- a/ruby/hyper-model/lib/reactive_record/active_record/class_methods.rb
+++ b/ruby/hyper-model/lib/reactive_record/active_record/class_methods.rb
@@ -197,14 +197,18 @@ module ActiveRecord
     ]
 
     def method_missing(name, *args, &block)
-      if name == 'human_attribute_name'
+      # In MRI Ruby we would never get to this point with a nil name argument,
+      #   but currently in Opal we do, so we will mimic MRI Ruby and throw a TypeError.
+      raise TypeError, "nil is not a symbol nor a string" if name.nil?
+
+      if name == "human_attribute_name"
         opts = args[1] || {}
         opts[:default] || args[0]
       elsif args.count == 1 && name.start_with?("find_by_") && !block
-        find_by(name.sub(/^find_by_/, '') => args[0])
+        find_by(name.sub(/^find_by_/, "") => args[0])
       elsif [].respond_to?(name)
         all.send(name, *args, &block)
-      elsif name.end_with?('!')
+      elsif name.end_with?("!")
         send(name.chop, *args, &block).send(:reload_from_db) rescue nil
       elsif !SERVER_METHODS.include?(name)
         raise "#{self.name}.#{name}(#{args}) (called class method missing)"

--- a/ruby/hyper-model/spec/batch1/active_record/class_methods_spec.rb
+++ b/ruby/hyper-model/spec/batch1/active_record/class_methods_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "ActiveRecord::ClassMethods", js: true do
+  context "method_missing" do
+    it "should return a TypeError if name is nil" do
+      expect_evaluate_ruby do
+        error = nil
+
+        begin
+          User.send(nil)
+        rescue StandardError => e
+          error = e
+        end
+
+        error
+      end.to eq("nil is not a symbol nor a string")
+    end
+  end
+end


### PR DESCRIPTION
In MRI Ruby, trying to pass `nil` into `.send` as a method name immediately throws an error. In Opal, this is not the case, Opal will continue on into any `method_missing`s you may define. Within HyperModel this can happen; inside of `ActiveRecord::ClassMethods#method_missing` we are calling `.end_with?` on the name argument, thus throwing an error when it is `nil`. This fixes that by mimicking MRI Ruby behavior and immediately throwing a `TypeError` if the name argument is `nil`.

I will also create an issue on Opal to see if they are aware of this behavior and whether or not it is intentional.

