### PR TITLE
Adds smarter lookup and fallback to I18n#t helper method

### DIFF
--- a/ruby/hyper-i18n/lib/hyperstack/i18n.rb
+++ b/ruby/hyper-i18n/lib/hyperstack/i18n.rb
@@ -1,13 +1,46 @@
 module Hyperstack
   module I18n
-    def t(attribute, opts = {})
-      namespace = self.class.name.underscore.gsub(%r{::|/}, '.')
+    class MissingTranslationError < StandardError; end
 
-      Hyperstack::Internal::I18n.t("#{namespace}.#{attribute}", opts)
+    def t(key, opts = {})
+      namespace = self.class.name.underscore.gsub(%r{::|/}, ".")
+
+      translation = Hyperstack::Internal::I18n.t("#{namespace}.#{key}", opts)
+
+      # If intially not found and has components namespace, see if it's set without it
+      if translation_missing?(translation) && translation =~ /components\./
+        namespace = namespace.gsub("components.", "")
+
+        translation = Hyperstack::Internal::I18n.t("#{namespace}.#{key}", opts)
+      end
+
+      # If translation is still not found, try looking up just the key provided
+      if translation_missing?(translation)
+        translation = Hyperstack::Internal::I18n.t(key, opts)
+      end
+
+      if translation_missing?(translation)
+        raise MissingTranslationError, "Missing translation: #{namespace}.#{key}"
+      end
+
+      translation
+    rescue MissingTranslationError => e
+      # In the case of a missing translation return titleized key
+
+      # HACK: In hyper-operation, String#titleize is patched to return the string as-is,
+      #   so for now we have to manually titleize it
+      # TODO: Switch to use String#titleize if hyper-operation removes that patch
+      key.rpartition(".")[-1].split("_").map(&:capitalize).join(" ")
     end
 
     def l(time, format = :default, opts = {})
       Hyperstack::Internal::I18n.l(time, format, opts)
+    end
+
+    protected
+
+    def translation_missing?(translation)
+      translation.is_a?(String) && translation =~ /^translation missing:/
     end
   end
 end

--- a/ruby/hyper-i18n/spec/hyper_i18n_spec.rb
+++ b/ruby/hyper-i18n/spec/hyper_i18n_spec.rb
@@ -16,11 +16,15 @@ describe 'I18n client methods', js: true do
             DIV(id: :tp4) { l(Time.parse('1/1/2018 12:45'), '%B %d, %Y at %l:%M %P') }
             DIV(id: :tp5) { MyModel.model_name.human }
             DIV(id: :tp6) { MyModel.human_attribute_name('the_attribute') }
+            DIV(id: :tp7) { t(:hello) }
+            DIV(id: :tp8) { t(:hello_world) }
+            DIV(id: :tp9) { t(:that_other_key) }
           end
         end
       end
     end
   end
+
   [['component rendering', :client_only], ['prerendering', :server_only]].each do |mode, flag|
     it "will translate during #{mode}", prerendering_on: flag == :server_only do
       mount 'Components::TestComponent', {}, render_on: flag
@@ -30,6 +34,9 @@ describe 'I18n client methods', js: true do
       expect(find('#tp4')).to have_content(::I18n.l(Time.parse('1/1/2018 12:45'), format: '%B %d, %Y at %l:%M %P'))
       expect(find('#tp5')).to have_content('My Model')
       expect(find('#tp6')).to have_content('The Attribute')
+      expect(find('#tp7')).to have_content('Hello world')
+      expect(find('#tp8')).to have_content('Hello World')
+      expect(find('#tp9')).to have_content('I am another key')
     end
   end
 end

--- a/ruby/hyper-i18n/spec/test_app/config/locales/en.yml
+++ b/ruby/hyper-i18n/spec/test_app/config/locales/en.yml
@@ -9,3 +9,5 @@ en:
   components:
     test_component:
       the_key: I am a key
+  test_component:
+    that_other_key: I am another key


### PR DESCRIPTION
Fixes #410 

This adds fallback lookup to the `I18n#t` helper method available for components. It first checks the full namespace as it did before, but also will then look without the components namespace (if applicable), then lookup just the key provided, and finally return the key titleized if the translation is missing (this mimics the server-side behavior in views).

One thing to add - I had to manually perform the titleize call, because hyper-operation patches `String#titleize` to return itself with no modification.